### PR TITLE
[DELIVERY] 상품별 배송 지원 - productId 필드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'com.github.smartlogismsa:common-module:v0.0.10'
     implementation 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/src/main/java/com/smartlogis/deliveryservice/application/dto/event/DeliveryRouteEvent.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/dto/event/DeliveryRouteEvent.java
@@ -1,0 +1,22 @@
+package com.smartlogis.deliveryservice.application.dto.event;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeliveryRouteEvent {
+	private UUID orderId;
+	private UUID departureHubId;
+	private UUID destinationHubId;
+	private String address;
+	private UUID receiptUserId;
+	private List<RouteInfo> routes;
+}

--- a/src/main/java/com/smartlogis/deliveryservice/application/dto/event/DeliveryRouteEvent.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/dto/event/DeliveryRouteEvent.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class DeliveryRouteEvent {
 	private UUID orderId;
+	private UUID productId;
 	private UUID departureHubId;
 	private UUID destinationHubId;
 	private String address;

--- a/src/main/java/com/smartlogis/deliveryservice/application/dto/event/RouteInfo.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/dto/event/RouteInfo.java
@@ -1,0 +1,21 @@
+package com.smartlogis.deliveryservice.application.dto.event;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RouteInfo {
+	private Integer sequence;
+	private UUID departureHubId;
+	private UUID destinationHubId;
+	private BigDecimal expectedDistanceKm;
+	private Integer expectedDurationMin;
+}

--- a/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
@@ -1,0 +1,41 @@
+package com.smartlogis.deliveryservice.application.event;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.smartlogis.deliveryservice.application.dto.event.DeliveryRouteEvent;
+import com.smartlogis.deliveryservice.application.service.DeliveryHistoryService;
+import com.smartlogis.deliveryservice.application.service.DeliveryService;
+import com.smartlogis.deliveryservice.domain.entity.Delivery;
+import com.smartlogis.deliveryservice.domain.repository.DeliveryRepository;
+import com.smartlogis.deliveryservice.infrastructure.config.RabbitMQConfig;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeliveryEventListener {
+
+	private final DeliveryService deliveryService;
+	private final DeliveryHistoryService deliveryHistoryService;
+	private final DeliveryRepository deliveryRepository;
+
+	@RabbitListener(queues = RabbitMQConfig.DELIVERY_ROUTE_QUEUE)
+	@Transactional
+	public void handleDeliveryRouteEvent(DeliveryRouteEvent event) {
+		Delivery delivery = deliveryService.createDelivery(
+			event.getOrderId(),
+			event.getDepartureHubId(),
+			event.getDestinationHubId(),
+			event.getAddress(),
+			event.getReceiptUserId()
+		);
+
+		deliveryHistoryService.createDeliveryHistories(delivery, event.getRoutes());
+
+		deliveryRepository.save(delivery);
+	}
+}

--- a/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
@@ -28,6 +28,7 @@ public class DeliveryEventListener {
 	public void handleDeliveryRouteEvent(DeliveryRouteEvent event) {
 		Delivery delivery = deliveryService.createDelivery(
 			event.getOrderId(),
+			event.getProductId(),
 			event.getDepartureHubId(),
 			event.getDestinationHubId(),
 			event.getAddress(),

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryService.java
@@ -1,5 +1,6 @@
 package com.smartlogis.deliveryservice.application.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.smartlogis.common.presentation.dto.PageRequest;
 import com.smartlogis.common.presentation.dto.PageResponse;
+import com.smartlogis.deliveryservice.application.dto.event.RouteInfo;
+import com.smartlogis.deliveryservice.domain.entity.Delivery;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryHistory;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryHistoryStatus;
 import com.smartlogis.deliveryservice.domain.exception.DeliveryHistoryNotFoundException;
@@ -24,6 +27,22 @@ import lombok.RequiredArgsConstructor;
 public class DeliveryHistoryService {
 
 	private final DeliveryHistoryRepository deliveryHistoryRepository;
+
+	@Transactional
+	public void createDeliveryHistories(Delivery delivery, List<RouteInfo> routes) {
+		for (RouteInfo route : routes) {
+			DeliveryHistory history = DeliveryHistory.create(
+				delivery,
+				route.getSequence(),
+				route.getDepartureHubId(),
+				route.getDestinationHubId(),
+				route.getExpectedDistanceKm(),
+				route.getExpectedDurationMin()
+			);
+
+			delivery.addDeliveryHistory(history);
+		}
+	}
 
 	@Transactional(readOnly = true)
 	public DeliveryHistoryResponse getDeliveryHistory(UUID deliveryHistoryId) {

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
@@ -25,6 +25,27 @@ public class DeliveryService {
 
 	private final DeliveryRepository deliveryRepository;
 
+	@Transactional
+	public UUID createDelivery(
+		UUID orderId,
+		UUID departureHubId,
+		UUID destinationHubId,
+		String address,
+		UUID receiptUserId
+	) {
+		Delivery delivery = Delivery.create(
+			orderId,
+			departureHubId,
+			destinationHubId,
+			address,
+			receiptUserId
+		);
+
+		deliveryRepository.save(delivery);
+
+		return delivery.getId();
+	}
+
 	@Transactional(readOnly = true)
 	public DeliveryResponse getDelivery(UUID deliveryId) {
 		Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
@@ -28,6 +28,7 @@ public class DeliveryService {
 	@Transactional
 	public Delivery createDelivery(
 		UUID orderId,
+		UUID productId,
 		UUID departureHubId,
 		UUID destinationHubId,
 		String address,
@@ -35,6 +36,7 @@ public class DeliveryService {
 	) {
 		Delivery delivery = Delivery.create(
 			orderId,
+			productId,
 			departureHubId,
 			destinationHubId,
 			address,

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
@@ -26,7 +26,7 @@ public class DeliveryService {
 	private final DeliveryRepository deliveryRepository;
 
 	@Transactional
-	public UUID createDelivery(
+	public Delivery createDelivery(
 		UUID orderId,
 		UUID departureHubId,
 		UUID destinationHubId,
@@ -41,9 +41,7 @@ public class DeliveryService {
 			receiptUserId
 		);
 
-		deliveryRepository.save(delivery);
-
-		return delivery.getId();
+		return deliveryRepository.save(delivery);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/smartlogis/deliveryservice/domain/entity/Delivery.java
+++ b/src/main/java/com/smartlogis/deliveryservice/domain/entity/Delivery.java
@@ -38,6 +38,9 @@ public class Delivery extends AbstractEntity {
 	@Column(name = "order_id", nullable = false)
 	private UUID orderId;
 
+	@Column(name = "product_id", nullable = false)
+	private UUID productId;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false)
 	private DeliveryStatus status;
@@ -63,6 +66,7 @@ public class Delivery extends AbstractEntity {
 	@Builder
 	public static Delivery create(
 		UUID orderId,
+		UUID productId,
 		UUID departureHubId,
 		UUID destinationHubId,
 		String address,
@@ -71,6 +75,7 @@ public class Delivery extends AbstractEntity {
 		Delivery delivery = new Delivery();
 		delivery.id = UUID.randomUUID();
 		delivery.orderId = orderId;
+		delivery.productId = productId;
 		delivery.status = DeliveryStatus.HUB_PENDING;
 		delivery.departureHubId = departureHubId;
 		delivery.destinationHubId = destinationHubId;

--- a/src/main/java/com/smartlogis/deliveryservice/infrastructure/config/RabbitMQConfig.java
+++ b/src/main/java/com/smartlogis/deliveryservice/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,57 @@
+package com.smartlogis.deliveryservice.infrastructure.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableRabbit
+public class RabbitMQConfig {
+
+	public static final String DELIVERY_ROUTE_QUEUE = "delivery.route.queue";
+	public static final String DELIVERY_EXCHANGE = "delivery.exchange";
+	public static final String DELIVERY_ROUTE_ROUTING_KEY = "delivery.route.created";
+
+	@Bean
+	public Queue deliveryRouteQueue() {
+		return new Queue(DELIVERY_ROUTE_QUEUE, true);
+	}
+
+	@Bean
+	public TopicExchange deliveryExchange() {
+		return new TopicExchange(DELIVERY_EXCHANGE);
+	}
+
+	@Bean
+	public Binding deliveryRouteBinding() {
+		return BindingBuilder
+			.bind(deliveryRouteQueue())
+			.to(deliveryExchange())
+			.with(DELIVERY_ROUTE_ROUTING_KEY);
+	}
+
+	@Bean
+	public MessageConverter messageConverter(){
+		return new Jackson2JsonMessageConverter();
+	}
+
+	@Bean
+	public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+		ConnectionFactory connectionFactory,
+		MessageConverter messageConverter
+	) {
+		SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+		factory.setConnectionFactory(connectionFactory);
+		factory.setMessageConverter(messageConverter);
+		return factory;
+	}
+
+}

--- a/src/test/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListenerTest.java
+++ b/src/test/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListenerTest.java
@@ -49,6 +49,7 @@ class DeliveryEventListenerTest {
 	void handleDeliveryRouteEvent_Success() {
 		// given
 		UUID orderId = UUID.randomUUID();
+		UUID productId = UUID.randomUUID();
 		UUID departureHubId = UUID.randomUUID();
 		UUID destinationHubId = UUID.randomUUID();
 		String address = "서울시 강남구";
@@ -72,6 +73,7 @@ class DeliveryEventListenerTest {
 
 		DeliveryRouteEvent event = DeliveryRouteEvent.builder()
 			.orderId(orderId)
+			.productId(productId)
 			.departureHubId(departureHubId)
 			.destinationHubId(destinationHubId)
 			.address(address)
@@ -81,6 +83,7 @@ class DeliveryEventListenerTest {
 
 		Delivery mockDelivery = Delivery.create(
 			orderId,
+			productId,
 			departureHubId,
 			destinationHubId,
 			address,
@@ -89,6 +92,7 @@ class DeliveryEventListenerTest {
 
 		given(deliveryService.createDelivery(
 			eq(orderId),
+			eq(productId),
 			eq(departureHubId),
 			eq(destinationHubId),
 			eq(address),
@@ -105,7 +109,7 @@ class DeliveryEventListenerTest {
 
 		// then
 		then(deliveryService).should(times(1))
-			.createDelivery(orderId, departureHubId, destinationHubId, address, receiptUserId);
+			.createDelivery(orderId, productId, departureHubId, destinationHubId, address, receiptUserId);
 
 		then(deliveryHistoryService).should(times(1))
 			.createDeliveryHistories(mockDelivery, event.getRoutes());

--- a/src/test/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListenerTest.java
+++ b/src/test/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListenerTest.java
@@ -1,0 +1,116 @@
+package com.smartlogis.deliveryservice.application.event;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.smartlogis.deliveryservice.TestMessageResolver;
+import com.smartlogis.deliveryservice.application.dto.event.DeliveryRouteEvent;
+import com.smartlogis.deliveryservice.application.dto.event.RouteInfo;
+import com.smartlogis.deliveryservice.application.service.DeliveryHistoryService;
+import com.smartlogis.deliveryservice.application.service.DeliveryService;
+import com.smartlogis.deliveryservice.domain.entity.Delivery;
+import com.smartlogis.deliveryservice.domain.repository.DeliveryRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeliveryEventListener 테스트")
+class DeliveryEventListenerTest {
+
+	@Mock
+	private DeliveryService deliveryService;
+
+	@Mock
+	private DeliveryHistoryService deliveryHistoryService;
+
+	@Mock
+	private DeliveryRepository deliveryRepository;
+
+	@InjectMocks
+	private DeliveryEventListener deliveryEventListener;
+
+	@BeforeEach
+	void setUp() {
+		TestMessageResolver.initializeMessageResource();
+	}
+
+	@Test
+	@DisplayName("배송 경로 이벤트 수신 시 배송 및 배송 기록 생성")
+	void handleDeliveryRouteEvent_Success() {
+		// given
+		UUID orderId = UUID.randomUUID();
+		UUID departureHubId = UUID.randomUUID();
+		UUID destinationHubId = UUID.randomUUID();
+		String address = "서울시 강남구";
+		UUID receiptUserId = UUID.randomUUID();
+
+		RouteInfo route1 = RouteInfo.builder()
+			.sequence(1)
+			.departureHubId(departureHubId)
+			.destinationHubId(UUID.randomUUID())
+			.expectedDistanceKm(new BigDecimal("100.5"))
+			.expectedDurationMin(120)
+			.build();
+
+		RouteInfo route2 = RouteInfo.builder()
+			.sequence(2)
+			.departureHubId(UUID.randomUUID())
+			.destinationHubId(destinationHubId)
+			.expectedDistanceKm(new BigDecimal("50.3"))
+			.expectedDurationMin(60)
+			.build();
+
+		DeliveryRouteEvent event = DeliveryRouteEvent.builder()
+			.orderId(orderId)
+			.departureHubId(departureHubId)
+			.destinationHubId(destinationHubId)
+			.address(address)
+			.receiptUserId(receiptUserId)
+			.routes(List.of(route1, route2))
+			.build();
+
+		Delivery mockDelivery = Delivery.create(
+			orderId,
+			departureHubId,
+			destinationHubId,
+			address,
+			receiptUserId
+		);
+
+		given(deliveryService.createDelivery(
+			eq(orderId),
+			eq(departureHubId),
+			eq(destinationHubId),
+			eq(address),
+			eq(receiptUserId)
+		)).willReturn(mockDelivery);
+
+		willDoNothing().given(deliveryHistoryService)
+			.createDeliveryHistories(eq(mockDelivery), eq(event.getRoutes()));
+
+		given(deliveryRepository.save(any(Delivery.class))).willReturn(mockDelivery);
+
+		// when
+		deliveryEventListener.handleDeliveryRouteEvent(event);
+
+		// then
+		then(deliveryService).should(times(1))
+			.createDelivery(orderId, departureHubId, destinationHubId, address, receiptUserId);
+
+		then(deliveryHistoryService).should(times(1))
+			.createDeliveryHistories(mockDelivery, event.getRoutes());
+
+		then(deliveryRepository).should(times(1))
+			.save(mockDelivery);
+	}
+}

--- a/src/test/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryServiceTest.java
+++ b/src/test/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryServiceTest.java
@@ -54,6 +54,7 @@ class DeliveryHistoryServiceTest {
 			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),
+			UUID.randomUUID(),
 			"서울시 강남구",
 			UUID.randomUUID()
 		);
@@ -114,6 +115,7 @@ class DeliveryHistoryServiceTest {
 
 		Delivery delivery = Delivery.create(
 			UUID.randomUUID(),
+			UUID.randomUUID(),
 			departureHubId,
 			destinationHubId,
 			"서울시 강남구",
@@ -158,6 +160,7 @@ class DeliveryHistoryServiceTest {
 		// given
 		UUID deliveryHistoryId = UUID.randomUUID();
 		Delivery delivery = Delivery.create(
+			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),

--- a/src/test/java/com/smartlogis/deliveryservice/application/service/DeliveryServiceTest.java
+++ b/src/test/java/com/smartlogis/deliveryservice/application/service/DeliveryServiceTest.java
@@ -52,6 +52,7 @@ class DeliveryServiceTest {
 			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),
+			UUID.randomUUID(),
 			"서울시 강남구",
 			UUID.randomUUID()
 		);
@@ -95,6 +96,7 @@ class DeliveryServiceTest {
 		// given
 		UUID orderId = UUID.randomUUID();
 		DeliveryStatus status = DeliveryStatus.HUB_PENDING;
+		UUID productId = UUID.randomUUID();
 		UUID departureHubId = UUID.randomUUID();
 		UUID destinationHubId = UUID.randomUUID();
 		UUID companyDeliveryManagerId = UUID.randomUUID();
@@ -104,6 +106,7 @@ class DeliveryServiceTest {
 
 		Delivery delivery = Delivery.create(
 			orderId,
+			productId,
 			departureHubId,
 			destinationHubId,
 			"서울시 강남구",
@@ -139,6 +142,7 @@ class DeliveryServiceTest {
 		// given
 		UUID deliveryId = UUID.randomUUID();
 		Delivery delivery = Delivery.create(
+			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),
 			UUID.randomUUID(),


### PR DESCRIPTION
## 📝 요약 (Summary)
상품별 배송을 반영하기 위해 `DeliveryRouteEvent`에 `productId` 필드를 추가했습니다.


## 🛠️ 작업 내용 (Details)

  - DeliveryRouteEvent: productId 필드 추가로 배송 이벤트에 상품 정보 포함
  - DeliveryService.createDelivery(): 메서드 시그니처 수정
    - productId 파라미터 추가 (배송 생성 시 상품별 추적 가능)
  - DeliveryEventListener: Hub Service 이벤트에서 productId 전달
  - 배송 기록: 상품별로 배송 기록(DeliveryHistory) 저장 가능

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [ ] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [x] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
