### PR TITLE
[DELIVERY] 배송 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/event/DeliveryEventListener.java
@@ -12,9 +12,7 @@ import com.smartlogis.deliveryservice.domain.repository.DeliveryRepository;
 import com.smartlogis.deliveryservice.infrastructure.config.RabbitMQConfig;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DeliveryEventListener {

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryHistoryService.java
@@ -15,6 +15,7 @@ import com.smartlogis.deliveryservice.application.dto.event.RouteInfo;
 import com.smartlogis.deliveryservice.domain.entity.Delivery;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryHistory;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryHistoryStatus;
+import com.smartlogis.deliveryservice.domain.entity.DeliveryStatus;
 import com.smartlogis.deliveryservice.domain.exception.DeliveryHistoryNotFoundException;
 import com.smartlogis.deliveryservice.domain.exception.DeliveryMessageCode;
 import com.smartlogis.deliveryservice.domain.repository.DeliveryHistoryRepository;
@@ -87,5 +88,67 @@ public class DeliveryHistoryService {
 		deliveryHistory.delete();
 
 		deliveryHistoryRepository.save(deliveryHistory);
+	}
+
+	@Transactional
+	public void startHubDelivery(UUID deliveryHistoryId) {
+		DeliveryHistory deliveryHistory = deliveryHistoryRepository.findByIdAndDeletedAtIsNull(deliveryHistoryId)
+			.orElseThrow(() -> new DeliveryHistoryNotFoundException(DeliveryMessageCode.DELIVERY_HISTORY_NOT_FOUND));
+
+		deliveryHistory.startHubDelivery();
+		deliveryHistoryRepository.save(deliveryHistory);
+
+		Delivery delivery = deliveryHistory.getDelivery();
+		if (delivery.getStatus() != DeliveryStatus.HUB_MOVING) {
+			delivery.startHubDelivery();
+		}
+	}
+
+	@Transactional
+	public void arriveAtDestinationHub(UUID deliveryHistoryId, java.math.BigDecimal actualDistance, Integer actualDuration) {
+		DeliveryHistory deliveryHistory = deliveryHistoryRepository.findByIdAndDeletedAtIsNull(deliveryHistoryId)
+			.orElseThrow(() -> new DeliveryHistoryNotFoundException(DeliveryMessageCode.DELIVERY_HISTORY_NOT_FOUND));
+
+		deliveryHistory.arriveAtDestinationHub(actualDistance, actualDuration);
+		deliveryHistoryRepository.save(deliveryHistory);
+
+		Delivery delivery = deliveryHistory.getDelivery();
+		boolean allHubStagesCompleted = delivery.getActiveDeliveryHistories().stream()
+			.allMatch(history -> history.getStatus() == DeliveryHistoryStatus.DESTINATION_HUB_ARRIVED);
+
+		if (allHubStagesCompleted && delivery.getStatus() == DeliveryStatus.HUB_MOVING) {
+			delivery.arriveAtDestinationHub();
+		}
+	}
+
+	@Transactional
+	public void startCompanyDelivery(UUID deliveryHistoryId) {
+		DeliveryHistory deliveryHistory = deliveryHistoryRepository.findByIdAndDeletedAtIsNull(deliveryHistoryId)
+			.orElseThrow(() -> new DeliveryHistoryNotFoundException(DeliveryMessageCode.DELIVERY_HISTORY_NOT_FOUND));
+
+		deliveryHistory.startCompanyDelivery();
+		deliveryHistoryRepository.save(deliveryHistory);
+
+		Delivery delivery = deliveryHistory.getDelivery();
+		if (delivery.getStatus() != DeliveryStatus.COMPANY_MOVING) {
+			delivery.startCompanyDelivery();
+		}
+	}
+
+	@Transactional
+	public void completeDelivery(UUID deliveryHistoryId, java.math.BigDecimal actualDistance, Integer actualDuration) {
+		DeliveryHistory deliveryHistory = deliveryHistoryRepository.findByIdAndDeletedAtIsNull(deliveryHistoryId)
+			.orElseThrow(() -> new DeliveryHistoryNotFoundException(DeliveryMessageCode.DELIVERY_HISTORY_NOT_FOUND));
+
+		deliveryHistory.arriveAtCompany(actualDistance, actualDuration);
+		deliveryHistoryRepository.save(deliveryHistory);
+
+		Delivery delivery = deliveryHistory.getDelivery();
+		boolean allHistoriesCompleted = delivery.getActiveDeliveryHistories().stream()
+			.allMatch(history -> history.getStatus() == DeliveryHistoryStatus.DESTINATION_COMPANY_ARRIVED);
+
+		if (allHistoriesCompleted) {
+			delivery.completeDelivery();
+		}
 	}
 }

--- a/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
+++ b/src/main/java/com/smartlogis/deliveryservice/application/service/DeliveryService.java
@@ -82,6 +82,34 @@ public class DeliveryService {
 	}
 
 	@Transactional
+	public void updateDeliveryStatus(UUID deliveryId, DeliveryStatus status) {
+		Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
+			.orElseThrow(() -> new DeliveryNotFoundException(DeliveryMessageCode.DELIVERY_NOT_FOUND));
+
+		switch (status) {
+			case HUB_MOVING:
+				delivery.startHubDelivery();
+				break;
+			case COMPANY_PENDING:
+				delivery.arriveAtDestinationHub();
+				break;
+			case COMPANY_MOVING:
+				delivery.startCompanyDelivery();
+				break;
+			case DELIVERED:
+				delivery.completeDelivery();
+				break;
+			case CANCELED:
+				delivery.cancel();
+				break;
+			default:
+				break;
+		}
+
+		deliveryRepository.save(delivery);
+	}
+
+	@Transactional
 	public void deleteDelivery(UUID deliveryId) {
 		Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId)
 			.orElseThrow(() -> new DeliveryNotFoundException(DeliveryMessageCode.DELIVERY_NOT_FOUND));

--- a/src/main/java/com/smartlogis/deliveryservice/domain/entity/DeliveryHistory.java
+++ b/src/main/java/com/smartlogis/deliveryservice/domain/entity/DeliveryHistory.java
@@ -118,4 +118,20 @@ public class DeliveryHistory extends AbstractEntity {
 		this.actualDistanceKm = actualDistance;
 		this.actualDurationMin = actualDuration;
 	}
+
+	public void startCompanyDelivery() {
+		if (this.status != DeliveryHistoryStatus.COMPANY_PENDING) {
+			throw new InvalidDeliveryHistoryStatusException(DeliveryMessageCode.DELIVERY_HISTORY_INVALID_STATUS);
+		}
+		this.status = DeliveryHistoryStatus.COMPANY_MOVING;
+	}
+
+	public void arriveAtCompany(BigDecimal actualDistance, Integer actualDuration) {
+		if (this.status != DeliveryHistoryStatus.COMPANY_MOVING) {
+			throw new InvalidDeliveryHistoryStatusException(DeliveryMessageCode.DELIVERY_HISTORY_INVALID_STATUS);
+		}
+		this.status = DeliveryHistoryStatus.DESTINATION_COMPANY_ARRIVED;
+		this.actualDistanceKm = actualDistance;
+		this.actualDurationMin = actualDuration;
+	}
 }

--- a/src/main/java/com/smartlogis/deliveryservice/domain/entity/DeliveryHistoryStatus.java
+++ b/src/main/java/com/smartlogis/deliveryservice/domain/entity/DeliveryHistoryStatus.java
@@ -8,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum DeliveryHistoryStatus {
 	HUB_PENDING("허브 이동 대기 중"),
 	HUB_MOVING("허브 배송 중"),
-	DESTINATION_HUB_ARRIVED("목적지 허브 도착");
+	DESTINATION_HUB_ARRIVED("목적지 허브 도착"),
+	COMPANY_PENDING("업체 배송 대기 중"),
+	COMPANY_MOVING("업체 배송 중"),
+	DESTINATION_COMPANY_ARRIVED("업체 도착");
 
 	private final String description;
 }

--- a/src/main/java/com/smartlogis/deliveryservice/interfaces/controller/DeliveryController.java
+++ b/src/main/java/com/smartlogis/deliveryservice/interfaces/controller/DeliveryController.java
@@ -7,16 +7,21 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 
 import com.smartlogis.common.presentation.ApiResponse;
 import com.smartlogis.common.presentation.dto.PageRequest;
 import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.deliveryservice.application.service.DeliveryService;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryStatus;
+import com.smartlogis.deliveryservice.interfaces.dto.request.DeliveryStatusUpdateRequest;
 import com.smartlogis.deliveryservice.interfaces.dto.response.DeliveryResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -75,6 +80,24 @@ public class DeliveryController {
 			orderId, status, departureHubId, destinationHubId, companyDeliveryManagerId, pageRequest
 		);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
+	}
+
+	@PatchMapping("/{deliveryId}/status")
+	@PreAuthorize("isAuthenticated()")
+	@Operation(
+		summary = "배송 상태 업데이트",
+		description = "배송의 상태를 업데이트합니다."
+	)
+	public ResponseEntity<ApiResponse<Void>> updateDeliveryStatus(
+		@PathVariable
+		@Parameter(description = "배송 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID deliveryId,
+		@RequestBody
+		@Valid
+		DeliveryStatusUpdateRequest request) {
+		DeliveryStatus status = DeliveryStatus.valueOf(request.getStatus());
+		deliveryService.updateDeliveryStatus(deliveryId, status);
+		return ResponseEntity.ok(ApiResponse.successWithDataOnly(null));
 	}
 
 	@DeleteMapping("/{deliveryId}")

--- a/src/main/java/com/smartlogis/deliveryservice/interfaces/controller/DeliveryHistoryController.java
+++ b/src/main/java/com/smartlogis/deliveryservice/interfaces/controller/DeliveryHistoryController.java
@@ -7,16 +7,21 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 
 import com.smartlogis.common.presentation.ApiResponse;
 import com.smartlogis.common.presentation.dto.PageRequest;
 import com.smartlogis.common.presentation.dto.PageResponse;
 import com.smartlogis.deliveryservice.application.service.DeliveryHistoryService;
 import com.smartlogis.deliveryservice.domain.entity.DeliveryHistoryStatus;
+import com.smartlogis.deliveryservice.interfaces.dto.request.DeliveryHistoryStatusUpdateRequest;
 import com.smartlogis.deliveryservice.interfaces.dto.response.DeliveryHistoryResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -75,6 +80,42 @@ public class DeliveryHistoryController {
 			deliveryId, departureHubId, destinationHubId, hubDeliveryManagerId, status, pageRequest
 		);
 		return ResponseEntity.ok(ApiResponse.successWithDataOnly(response));
+	}
+
+	@PatchMapping("/{deliveryHistoryId}/status")
+	@PreAuthorize("isAuthenticated()")
+	@Operation(
+		summary = "배송 기록 상태 업데이트",
+		description = "배송 기록의 상태를 업데이트합니다."
+	)
+	public ResponseEntity<ApiResponse<Void>> updateDeliveryHistoryStatus(
+		@PathVariable
+		@Parameter(description = "배송 기록 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+		UUID deliveryHistoryId,
+		@RequestBody
+		@Valid
+		DeliveryHistoryStatusUpdateRequest request) {
+		String status = request.getStatus();
+
+		if ("HUB_MOVING".equals(status)) {
+			deliveryHistoryService.startHubDelivery(deliveryHistoryId);
+		} else if ("DESTINATION_HUB_ARRIVED".equals(status)) {
+			deliveryHistoryService.arriveAtDestinationHub(
+				deliveryHistoryId,
+				request.getActualDistanceKm(),
+				request.getActualDurationMin()
+			);
+		} else if ("COMPANY_MOVING".equals(status)) {
+			deliveryHistoryService.startCompanyDelivery(deliveryHistoryId);
+		} else if ("DESTINATION_COMPANY_ARRIVED".equals(status)) {
+			deliveryHistoryService.completeDelivery(
+				deliveryHistoryId,
+				request.getActualDistanceKm(),
+				request.getActualDurationMin()
+			);
+		}
+
+		return ResponseEntity.ok(ApiResponse.successWithDataOnly(null));
 	}
 
 	@DeleteMapping("/{deliveryHistoryId}")

--- a/src/main/java/com/smartlogis/deliveryservice/interfaces/dto/request/DeliveryHistoryStatusUpdateRequest.java
+++ b/src/main/java/com/smartlogis/deliveryservice/interfaces/dto/request/DeliveryHistoryStatusUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.smartlogis.deliveryservice.interfaces.dto.request;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeliveryHistoryStatusUpdateRequest {
+	@NotBlank(message = "상태는 필수입니다")
+	private String status;
+
+	private BigDecimal actualDistanceKm;
+
+	private Integer actualDurationMin;
+}

--- a/src/main/java/com/smartlogis/deliveryservice/interfaces/dto/request/DeliveryStatusUpdateRequest.java
+++ b/src/main/java/com/smartlogis/deliveryservice/interfaces/dto/request/DeliveryStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.smartlogis.deliveryservice.interfaces.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeliveryStatusUpdateRequest {
+	@NotBlank(message = "상태는 필수입니다")
+	private String status;
+}


### PR DESCRIPTION
## 📝 요약 (Summary)

## 🛠️ 작업 내용 (Details)

  ### DeliveryHistoryStatus enum 확장

  업체 배송 단계 상태 추가:
  - COMPANY_PENDING: 업체 배송 대기 중
  - COMPANY_MOVING: 업체 배송 중
  - DESTINATION_COMPANY_ARRIVED: 업체 도착

 ### DeliveryHistory 상태 변경 API 추가

  - 엔드포인트: `PATCH /v1/delivery-histories/{deliveryHistoryId}/status`
  - 지원 상태:
    - HUB_MOVING: 허브 배송 시작
    - DESTINATION_HUB_ARRIVED: 허브 도착
    - COMPANY_MOVING: 업체 배송 시작
    - DESTINATION_COMPANY_ARRIVED: 업체 도착

  ### Delivery 상태 변경 API 추가

  - 엔드포인트: `PATCH /v1/deliveries/{deliveryId}/status`
  - 지원 상태: HUB_MOVING, COMPANY_PENDING, COMPANY_MOVING, DELIVERED, CANCELED

  ### Delivery ↔ DeliveryHistory 동기화

  - 배송 기록 상태 변경 시 배송 정보도 함께 업데이트
  - 모든 배송 기록 완료 시 배송 상태 자동 변경

  ### 신규 추가 파일/클래스

  - DeliveryStatusUpdateRequest: Delivery 상태 변경 요청 DTO
  - DeliveryService.updateDeliveryStatus(): 배송 상태 변경 메서드
  - DeliveryHistoryService.startHubDelivery(): 허브 배송 시작
  - DeliveryHistoryService.arriveAtDestinationHub(): 허브 도착 처리
  - DeliveryHistoryService.startCompanyDelivery(): 업체 배송 시작
  - DeliveryHistoryService.completeDelivery(): 배송 완료 처리

## 🔀 변경 유형 (Change Type)

- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
